### PR TITLE
Deferring clean-up until models are destroyed

### DIFF
--- a/addon/services/flash-message-service.js
+++ b/addon/services/flash-message-service.js
@@ -1,28 +1,28 @@
 import Ember from 'ember';
 import FlashMessage from 'flash-messages/models/flash';
- 
+
 export default Ember.Object.extend({
   queue:   Ember.A([]),
   content: Ember.computed.alias('queue'),
   isEmpty: Ember.computed.equal('queue.length', 0),
   timeout: 2000,
-  
+
   success: function(msg){
     this._add(msg, 'success');
   },
-  
+
   info: function(msg){
     this._add(msg, 'info');
   },
-  
+
   warning: function(msg){
     this._add(msg, 'warning');
   },
-  
+
   danger: function(msg){
     this._add(msg, 'danger');
   },
-  
+
   // private
   _add: function(msg, type){
     var flashes, flash;
@@ -30,28 +30,30 @@ export default Ember.Object.extend({
     flash   = this._newFlashMessage(msg, type);
     flashes.pushObject(flash);
   },
-  
+
   _newFlashMessage: function(msg, type){
     var timeout;
     Ember.assert('Must pass a valid flash message', msg);
     type    = (typeof type === 'undefined') ? 'info' : type;
     timeout = Ember.get(this, 'timeout');
-    
+
     return FlashMessage.create({
       type:    type,
       message: msg,
       timeout: timeout
     });
   },
-  
+
   _queueDidChange: Ember.observer('queue.@each.isDestroyed', function(){
     var flashes, destroyed, timeout;
     flashes =  Ember.get(this, 'queue');
     timeout =  Ember.get(this, 'timeout');
-    
-    Ember.run.later(this, function(){
-      destroyed = flashes.filterBy('isDestroyed', true);
-      return flashes.removeObjects(destroyed);
+
+    Ember.run.later(function(){
+      Ember.run.next(function() {
+        destroyed = flashes.filterBy('isDestroyed', true);
+        return flashes.removeObjects(destroyed);
+      });
     }, timeout);
   })
 });


### PR DESCRIPTION
The cleanup callback (the `Ember.run.later` within `_queueDidChange`) was being fired while the models were still being destroyed, so the `isDestroying` flag was `true`, but the `isDestroyed` flag was still false. This fix defers that cleanup until after that process is completed.

This wasn't a problem in the dummy app, but in production it was leaving the messages onscreen indefinitely, until the queue changed again.

Not sure if this is the best approach, but it works for me.
